### PR TITLE
feat: add metrics configuration to soak-test deployment

### DIFF
--- a/charts/benchmark-workers/templates/deployment-soak-test.yaml
+++ b/charts/benchmark-workers/templates/deployment-soak-test.yaml
@@ -27,6 +27,10 @@ spec:
       - name: benchmark-soak-test
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.metrics.port }}
+          protocol: TCP
         env:
         - name: TEMPORAL_GRPC_ENDPOINT
           value: {{ .Values.temporal.grpcEndpoint | quote }}
@@ -36,6 +40,10 @@ spec:
           value: {{ .Values.temporal.taskQueue | quote }}
         - name: CONCURRENT_WORKFLOWS
           value: {{ .Values.soakTest.concurrentWorkflows | quote }}
+        {{- if .Values.metrics.enabled }}
+        - name: PROMETHEUS_ENDPOINT
+          value: {{ .Values.metrics.prometheusEndpoint | quote }}
+        {{- end }}
         {{- if .Values.temporal.tls.enabled }}
         {{- if and .Values.temporal.tls.key .Values.temporal.tls.cert }}
         - name: TEMPORAL_TLS_KEY


### PR DESCRIPTION
## What was changed
This patch adds a `metric` named port and a `PROMETHEUS_ENDPOINT` environment variable to the soak-test deployment.

## Why?
I am trying to follow this blog post <https://temporal.io/blog/scaling-temporal-the-basics> to scale up my Temporal Service.

Unfortunately, I wasn't able to collect `StartExecutionWorkflow` latencies. I found that the deployment configuration was missing both a `metric` named port and a `PROMETHEUS_ENDPOINT` environment variable, which explained why I wasn't collecting any metric from this deployment.

## Checklist

2. How was this tested:

This is a before/after view 🙂 we notice that we start collecting `StartExecutionWorkflow` request latencies.

<img width="1634" height="1134" alt="image" src="https://github.com/user-attachments/assets/0d5668d8-9089-44d2-afcc-7c2bce35bfc1" />
